### PR TITLE
feat: Apple Musicトラックリンクに対応

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,44 @@
 import path from 'node:path';
 import { createSpotifyUtility } from 'spotify-utility';
 import getConfig from './config/env';
-import { readTrackUrisFromFile } from './utils';
+import { readTrackUrlsFromFile, UrlType, ParsedUrl } from './utils';
+import { fetchTrackMetadata, findSpotifyUri, toSpotifyUri } from './services/apple-music';
+
+/**
+ * パースされたURLをSpotify URIに変換する
+ * Apple Music URLの場合は、メタデータを取得してSpotifyで検索する
+ */
+async function convertToSpotifyUris(urls: ParsedUrl[], client: Awaited<ReturnType<typeof createSpotifyUtility>>): Promise<string[]> {
+  const spotifyUris: string[] = [];
+
+  for (const url of urls) {
+    if (url.type === UrlType.Spotify) {
+      // Spotify URLはそのままURIに変換
+      spotifyUris.push(toSpotifyUri(url.id));
+    } else if (url.type === UrlType.AppleMusic) {
+      // Apple Music URLはメタデータを取得してSpotifyで検索
+      console.log(`\nApple Music: ${url.originalUrl}`);
+      console.log(`  メタデータを取得中...`);
+      const metadata = await fetchTrackMetadata(url.id);
+      if (!metadata) {
+        console.log(`  ✗ メタデータの取得に失敗しました。スキップします。`);
+        continue;
+      }
+      console.log(`  曲名: ${metadata.trackName}`);
+      console.log(`  アーティスト: ${metadata.artistName}`);
+      console.log(`  ISRC: ${metadata.isrc || 'なし'}`);
+
+      const spotifyUri = await findSpotifyUri(metadata, client);
+      if (spotifyUri) {
+        spotifyUris.push(spotifyUri);
+      } else {
+        console.log(`  ✗ Spotifyで見つかりませんでした。スキップします。`);
+      }
+    }
+  }
+
+  return spotifyUris;
+}
 
 async function main() {
   try {
@@ -17,15 +54,31 @@ async function main() {
 
     console.log('トラックファイルを読み込み中...');
     const tracksFilePath = path.resolve(process.cwd(), 'tracks.txt');
-    const fileTrackUris = new Set(await readTrackUrisFromFile(tracksFilePath));
-    console.log(`${fileTrackUris.size}件のトラックをファイルから検出`);
+    const parsedUrls = await readTrackUrlsFromFile(tracksFilePath);
+
+    const spotifyCount = parsedUrls.filter((u) => u.type === UrlType.Spotify).length;
+    const appleMusicCount = parsedUrls.filter((u) => u.type === UrlType.AppleMusic).length;
+
+    console.log(`${spotifyCount}件のSpotify URL、${appleMusicCount}件のApple Music URLを検出`);
+
+    if (parsedUrls.length === 0) {
+      console.log('追加するトラックがありません。終了します。');
+      return;
+    }
+
+    // Apple Music URLをSpotify URIに変換
+    if (appleMusicCount > 0) {
+      console.log('\nApple Music URLをSpotifyトラックに変換中...');
+    }
+    const fileTrackUris = new Set(await convertToSpotifyUris(parsedUrls, client));
+    console.log(`\n${fileTrackUris.size}件のトラックを処理対象として検出`);
 
     if (fileTrackUris.size === 0) {
       console.log('追加するトラックがありません。終了します。');
       return;
     }
 
-    console.log('お気に入り曲を取得中...');
+    console.log('\nお気に入り曲を取得中...');
     const savedTrackUris = await client.tracks.listMyFavoriteUris();
     console.log(`${savedTrackUris.size}件のお気に入り曲を取得`);
 

--- a/src/services/apple-music.ts
+++ b/src/services/apple-music.ts
@@ -1,0 +1,175 @@
+/**
+ * Apple Music関連の処理を行うモジュール
+ */
+
+/**
+ * Apple Musicのトラックメタデータ
+ */
+interface AppleMusicTrackMetadata {
+  trackId: string;
+  trackName: string;
+  artistName: string;
+  collectionName?: string;
+  isrc?: string;
+}
+
+/**
+ * iTunes Search APIのレスポンス型
+ */
+interface ITunesSearchResponse {
+  resultCount: number;
+  results: Array<{
+    trackId: number;
+    trackName: string;
+    artistName: string;
+    collectionName?: string;
+    trackViewUrl: string;
+    isrc?: string;
+  }>;
+}
+
+/**
+ * Apple MusicのトラックURLからトラックIDを抽出する
+ *
+ * 対応URL形式:
+ * - https://music.apple.com/{country}/album/{album}/{trackId}
+ * - https://music.apple.com/{country}/album/{album}
+ *
+ * @param url - Apple MusicのトラックURL
+ * @returns トラックID、またはパースに失敗した場合はnull
+ */
+export function parseAppleMusicUrl(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+
+    // ドメインチェック
+    if (urlObj.hostname !== 'music.apple.com') {
+      return null;
+    }
+
+    const pathSegments = urlObj.pathname.split('/').filter(Boolean);
+
+    // パス構造: [{country}/album/{album}/]???
+    // Apple MusicのトラックURLの末尾には、通常英数字のID（またはスラグ+IDの形式）が含まれる
+    // 例: https://music.apple.com/jp/album/track-name/123456789?i=987654321
+    // URLクエリパラメータの i= がトラックIDの場合が多い
+
+    // クエリパラメータからトラックIDを取得
+    const trackIdFromQuery = urlObj.searchParams.get('i');
+    if (trackIdFromQuery) {
+      return trackIdFromQuery;
+    }
+
+    // パスの最後のセグメントがトラックIDの場合
+    // アルバムIDとトラックIDを区別するために、クエリパラメータを優先
+    if (pathSegments.length >= 4) {
+      // {country}/album/{album}/{id}
+      const lastSegment = pathSegments[pathSegments.length - 1];
+      // 数字のみで構成されている場合はIDとみなす
+      if (/^\d+$/.test(lastSegment)) {
+        return lastSegment;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * iTunes Search APIを使用してトラックメタデータを取得する
+ *
+ * @param trackId - Apple MusicのトラックID
+ * @returns トラックメタデータ、または取得に失敗した場合はnull
+ */
+export async function fetchTrackMetadata(trackId: string): Promise<AppleMusicTrackMetadata | null> {
+  try {
+    const url = new URL('https://itunes.apple.com/lookup');
+    url.searchParams.set('id', trackId);
+    url.searchParams.set('country', 'JP'); // デフォルトは日本
+    url.searchParams.set('entity', 'song');
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      console.warn(`iTunes API request failed: ${response.status}`);
+      return null;
+    }
+
+    const data: ITunesSearchResponse = await response.json();
+
+    if (data.resultCount === 0 || !data.results[0]) {
+      console.warn(`No metadata found for track ID: ${trackId}`);
+      return null;
+    }
+
+    const track = data.results[0];
+    return {
+      trackId: String(track.trackId),
+      trackName: track.trackName,
+      artistName: track.artistName,
+      collectionName: track.collectionName,
+      isrc: track.isrc,
+    };
+  } catch (error) {
+    console.warn(`Failed to fetch Apple Music metadata for ${trackId}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Spotify URI形式に変換するためのヘルパー関数
+ *
+ * @param spotifyTrackId - SpotifyのトラックID
+ * @returns Spotify URI形式
+ */
+export function toSpotifyUri(spotifyTrackId: string): string {
+  return `spotify:track:${spotifyTrackId}`;
+}
+
+/**
+ * Spotify APIでトラックを検索する
+ *
+ * @param metadata - Apple Musicのトラックメタデータ
+ * @param client - Spotifyクライアント（searchByIsrcとsearchを持つ）
+ * @returns Spotify URI、または見つからない場合はnull
+ */
+export async function findSpotifyUri(
+  metadata: AppleMusicTrackMetadata,
+  client: {
+    tracks: {
+      searchByIsrc: (isrc: string) => Promise<string | null>;
+      search: (query: string, options?: { limit: number }) => Promise<{ id: string }[]>;
+    };
+  }
+): Promise<string | null> {
+  try {
+    // 優先度1: ISRCマッチング（最も正確）
+    if (metadata.isrc) {
+      console.log(`  ISRCで検索中: ${metadata.isrc}`);
+      const spotifyUri = await client.tracks.searchByIsrc(metadata.isrc);
+      if (spotifyUri) {
+        console.log(`  ✓ ISRCマッチ: ${metadata.trackName} - ${metadata.artistName}`);
+        return spotifyUri;
+      }
+      console.log(`  ✗ ISRCマッチなし`);
+    }
+
+    // 優先度2: キーワード検索（フォールバック）
+    const query = `track:${metadata.trackName} artist:${metadata.artistName}`;
+    console.log(`  キーワードで検索中: ${query}`);
+
+    const results = await client.tracks.search(query, { limit: 1 });
+
+    if (results.length > 0) {
+      console.log(`  ✓ キーワードマッチ: ${metadata.trackName} - ${metadata.artistName}`);
+      return toSpotifyUri(results[0].id);
+    }
+
+    console.log(`  ✗ マッチするトラックが見つかりませんでした`);
+    return null;
+  } catch (error) {
+    console.warn(`  Spotify検索エラー (${metadata.trackName}):`, error);
+    return null;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,58 @@
 import fs from 'fs-extra';
+import { parseAppleMusicUrl } from './services/apple-music';
 
 /**
- * SpotifyのトラックURLからSpotify URIを抽出する
+ * URLの種別
  */
-export function convertTrackUri(url: string): string | null {
-  try {
-    const urlObj = new URL(url);
-    const pathSegments = urlObj.pathname.split('/').filter(Boolean);
+export enum UrlType {
+  Spotify = 'spotify',
+  AppleMusic = 'apple-music',
+  Unknown = 'unknown',
+}
 
-    if (pathSegments.length >= 2 && pathSegments[0] === 'track' && pathSegments[1].length === 22) {
-      const trackId = pathSegments[1];
-      return `spotify:track:${trackId}`;
+/**
+ * パースされたURL情報
+ */
+export interface ParsedUrl {
+  type: UrlType;
+  originalUrl: string;
+  id: string;
+}
+
+/**
+ * URLの種別を判定してパースする
+ */
+export function parseUrl(url: string): ParsedUrl | null {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return null;
+
+  try {
+    const urlObj = new URL(trimmedUrl);
+
+    // Spotify URL
+    if (urlObj.hostname === 'open.spotify.com') {
+      const pathSegments = urlObj.pathname.split('/').filter(Boolean);
+      if (pathSegments.length >= 2 && pathSegments[0] === 'track' && pathSegments[1].length === 22) {
+        return {
+          type: UrlType.Spotify,
+          originalUrl: trimmedUrl,
+          id: pathSegments[1],
+        };
+      }
     }
+
+    // Apple Music URL
+    if (urlObj.hostname === 'music.apple.com') {
+      const trackId = parseAppleMusicUrl(trimmedUrl);
+      if (trackId) {
+        return {
+          type: UrlType.AppleMusic,
+          originalUrl: trimmedUrl,
+          id: trackId,
+        };
+      }
+    }
+
     return null;
   } catch {
     return null;
@@ -19,9 +60,20 @@ export function convertTrackUri(url: string): string | null {
 }
 
 /**
- * テキストファイルからトラックURLを読み込み、Spotify URIのリストを返却
+ * SpotifyのトラックURLからSpotify URIを抽出する
  */
-export async function readTrackUrisFromFile(filePath: string): Promise<string[]> {
+export function convertSpotifyUri(url: string): string | null {
+  const parsed = parseUrl(url);
+  if (parsed?.type === UrlType.Spotify) {
+    return `spotify:track:${parsed.id}`;
+  }
+  return null;
+}
+
+/**
+ * テキストファイルからトラックURLを読み込み、パース済みURLのリストを返却
+ */
+export async function readTrackUrlsFromFile(filePath: string): Promise<ParsedUrl[]> {
   if (!(await fs.pathExists(filePath))) {
     throw new Error(`File not found: ${filePath}`);
   }
@@ -30,7 +82,19 @@ export async function readTrackUrisFromFile(filePath: string): Promise<string[]>
   const lines = content.split('\n');
 
   return lines
-    .map((line) => convertTrackUri(line.trim()))
-    .filter((uri) => uri !== null)
-    .filter((uri) => uri !== '');
+    .map((line) => parseUrl(line))
+    .filter((url): url is ParsedUrl => url !== null);
+}
+
+/**
+ * テキストファイルからトラックURLを読み込み、Spotify URIのリストを返却
+ * （Spotify URLのみ対応、Apple Music URLは無視される）
+ *
+ * @deprecated 代わりに readTrackUrlsFromFile を使用してください
+ */
+export async function readTrackUrisFromFile(filePath: string): Promise<string[]> {
+  const parsedUrls = await readTrackUrlsFromFile(filePath);
+  return parsedUrls
+    .filter((url) => url.type === UrlType.Spotify)
+    .map((url) => `spotify:track:${url.id}`);
 }


### PR DESCRIPTION
# 概要
-Apple MusicのトラックURLから楽曲惇ータを取得し、Spotify上で対応する楽曲を検索して追加する機能を追加
-iTunes Search APIを使用してメタデータ取得(ISRC含む)
-ISRCまたはキーワードでSpotify検索
-マッチしない場合はスキップ(誤検出回避)

# 実装詳細
```
- src/services/apple-music.ts (新規): Apple Music URLのパース、メタデータ取得、Spotify検索
- src/utils.ts: URL種別判定機能を追加
- src/index.ts: Apple Music URLをSpotify URIに変換する処理フローを統合
```

Closes #6

Generated with [Claude Code](https://claude.com/claude-code)